### PR TITLE
Recreate parameters when switching between layers with same generator type

### DIFF
--- a/gui-slint/ui/appwindow.slint
+++ b/gui-slint/ui/appwindow.slint
@@ -118,27 +118,29 @@ export component AppWindow inherits Window {
             }
         }
         VerticalLayout {
-            if root.selected_layer_index >= 0 : Rectangle {
-                if root.selected_algorithm == GeneratorType.perlin : PerlinPanel { 
-                    params <=> root.current_perlin_params;
+            for selected_layer_index in (root.selected_layer_index >= 0 ? [root.selected_layer_index] : []) : 
+                Rectangle {
+                    if root.selected_algorithm == GeneratorType.perlin : PerlinPanel { 
+                        params <=> root.current_perlin_params;
 
-                    params_changed => {
-                        if root.selected_layer_index >= 0 {
-                            root.update_perlin_params(self.params);
+                        params_changed => {
+                            if root.selected_layer_index >= 0 {
+                                root.update_perlin_params(self.params);
+                            }
+                        }
+                    }
+
+                    if root.selected_algorithm == GeneratorType.diamondsquare : DiamondSquarePanel {
+                        params <=> root.current_ds_params;
+
+                        params_changed => {
+                            if root.selected_layer_index >= 0 {
+                                root.update_ds_params(self.params);
+                            }
                         }
                     }
                 }
 
-                if root.selected_algorithm == GeneratorType.diamondsquare : DiamondSquarePanel {
-                    params <=> root.current_ds_params;
-
-                    params_changed => {
-                        if root.selected_layer_index >= 0 {
-                            root.update_ds_params(self.params);
-                        }
-                    }
-                }
-            }
             Rectangle {}
 
             Button {
@@ -149,7 +151,6 @@ export component AppWindow inherits Window {
                     root.invoke_generate(root.selected_algorithm);
                 }
             }
-            
         }
 
         VerticalLayout{


### PR DESCRIPTION
When switching to another layer with the same generator type, the parameters panel should be reinstantiated with the newly-selected layer's parameters.